### PR TITLE
Reformat DB to Isolate Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
       DB_PASS: ${{ secrets.DB_PASS }}
       DB_NAME: ${{ secrets.DB_NAME }}
       DB_PORT: ${{ secrets.DB_PORT }}
+      TEST_SCHEMA: ${{ secrets.TEST_SCHEMA }}
 
     steps:
       - name: Check out repository

--- a/app/app.js
+++ b/app/app.js
@@ -13,7 +13,9 @@ const schema =
     ? process.env.TEST_SCHEMA
     : process.env.LIVE_SCHEMA;
 app.use(cors());
+
 const port = 8000;
+const FK_VIOLATION = "23503";
 
 app.use(bodyParser.json());
 
@@ -244,7 +246,7 @@ app.post("/api/activity", async (req, res) => {
     ]);
     res.status(201).send(result.rows[0]);
   } catch (err) {
-    if (err.code === "23503") {
+    if (err.code === FK_VIOLATION) {
       return res.status(404).send(`Foreign key ${student_number} not found.`);
     }
     res.status(500).send(`Error creating activity: ${err}`);

--- a/app/app.js
+++ b/app/app.js
@@ -3,8 +3,15 @@ import moment from "moment-timezone";
 import bodyParser from "body-parser";
 import db from "./db.js";
 import cors from "cors";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const app = express();
+const schema =
+  process.env.NODE_ENV === "test"
+    ? process.env.TEST_SCHEMA
+    : process.env.LIVE_SCHEMA;
 app.use(cors());
 const port = 8000;
 
@@ -35,8 +42,7 @@ app.use(bodyParser.json());
 app.get("/api/gamer/:student_number", async (req, res) => {
   const { student_number } = req.params;
   try {
-    const query =
-      "SELECT * FROM users_test.gamer_profile WHERE student_number = $1";
+    const query = `SELECT * FROM ${schema}.gamer_profile WHERE student_number = $1`;
     const result = await db.query(query, [student_number]);
     if (result.rows.length === 0) {
       return res.status(404).send("Student not found");
@@ -82,7 +88,7 @@ app.post("/api/gamer", async (req, res) => {
   } = req.body;
   const created_at = moment().tz("America/Los_Angeles").format("YYYY-MM-DD");
 
-  const query = `INSERT INTO users_test.gamer_profile 
+  const query = `INSERT INTO ${schema}.gamer_profile 
       (first_name, last_name, student_number, membership_tier, banned, notes, created_at) 
       VALUES ($1, $2, $3, $4, $5, $6, $7) 
       ON CONFLICT (student_number) 
@@ -128,7 +134,7 @@ app.delete("/api/gamer/:student_number", async (req, res) => {
 
   try {
     const result = await db.query(
-      "DELETE FROM users_test.gamer_profile WHERE student_number = $1 RETURNING *",
+      `DELETE FROM ${schema}.gamer_profile WHERE student_number = $1 RETURNING *`,
       [student_number],
     );
 
@@ -161,8 +167,7 @@ app.delete("/api/gamer/:student_number", async (req, res) => {
 app.get("/api/activity/:student_number", async (req, res) => {
   const { student_number } = req.params;
   try {
-    const query =
-      "SELECT * FROM users_test.gamer_activity WHERE student_number = $1";
+    const query = `SELECT * FROM ${schema}.gamer_activity WHERE student_number = $1`;
     const result = await db.query(query, [student_number]);
 
     res.json(result.rows);
@@ -188,7 +193,7 @@ app.get("/api/activity/:student_number", async (req, res) => {
  */
 app.get("/api/activity/all/recent", async (req, res) => {
   try {
-    const query = `SELECT * FROM users_test.gamer_activity
+    const query = `SELECT * FROM ${schema}.gamer_activity
       ORDER BY started_at 
       DESC NULLS LAST 
       LIMIT 20;`;
@@ -225,7 +230,7 @@ app.post("/api/activity", async (req, res) => {
     .tz("America/Los_Angeles")
     .format("YYYY-MM-DD HH:mm");
 
-  const query = `INSERT INTO users_test.gamer_activity 
+  const query = `INSERT INTO ${schema}.gamer_activity 
       (student_number, pc_number, game, started_at) 
       VALUES ($1, $2, $3, $4) 
       RETURNING *`;
@@ -240,7 +245,7 @@ app.post("/api/activity", async (req, res) => {
     res.status(201).send(result.rows[0]);
   } catch (err) {
     if (err.code === "23503") {
-      res.status(404).send(`Foreign key ${student_number} not found.`);
+      return res.status(404).send(`Foreign key ${student_number} not found.`);
     }
     res.status(500).send(`Error creating activity: ${err}`);
   }
@@ -269,13 +274,13 @@ app.patch("/api/activity/update/:student_number", async (req, res) => {
     .format("YYYY-MM-DD HH:mm");
   const { student_number } = req.params;
 
-  const query = `UPDATE users_test.gamer_activity
+  const query = `UPDATE ${schema}.gamer_activity
                  SET ended_at = $1 
                  WHERE student_number = $2
                  AND ended_at IS NULL
                  AND started_at = (
                   SELECT MAX(started_at) 
-                  FROM users_test.gamer_activity 
+                  FROM ${schema}.gamer_activity 
                   WHERE student_number = $2
                 )
                  RETURNING *`;

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,6 @@
     "pg": "^8.12.0"
   },
   "scripts": {
-    "test": "mocha tests/**/*.js --exit"
+    "test": "NODE_ENV=test mocha tests/**/*.js --exit"
   }
 }

--- a/app/tests/test_activity.js
+++ b/app/tests/test_activity.js
@@ -6,15 +6,29 @@ import db from "../db.js";
 describe("Activity API", () => {
   // Clean up the database before each test
   beforeEach(async () => {
-    await db.query("DROP TABLE IF EXISTS users_test.gamer_activity_test");
-    await db.query(
-      "CREATE TABLE users_test.gamer_activity_test (LIKE users_test.gamer_activity INCLUDING ALL)",
-    );
+    await db.query("TRUNCATE TABLE test.gamer_profile CASCADE;");
+    const mock1 = `
+      INSERT INTO test.gamer_profile 
+      (first_name, last_name, student_number, membership_tier) 
+      VALUES ('John', 'Doe', '11223344', 1);
+    `;
+    const mock2 = `
+      INSERT INTO test.gamer_profile 
+      (first_name, last_name, student_number, membership_tier) 
+      VALUES ('Jane', 'Doe', '87654321', 1);
+    `;
+    await db.query(mock1);
+    await db.query(mock2);
+    await db.query("TRUNCATE TABLE test.gamer_activity;");
   });
 
   // Clean up the database after each test
   afterEach(async () => {
-    await db.query("DROP TABLE IF EXISTS users_test.gamer_activity_test");
+    await db.query("TRUNCATE TABLE test.gamer_activity;");
+  });
+
+  after(async () => {
+    await db.query("TRUNCATE TABLE test.gamer_profile CASCADE;");
   });
 
   it("should add an activity", (done) => {

--- a/app/tests/test_api.js
+++ b/app/tests/test_api.js
@@ -6,15 +6,12 @@ import db from "../db.js";
 describe("Gamer API", () => {
   // Clean up the database before each test
   beforeEach(async () => {
-    await db.query("DROP TABLE IF EXISTS users_test.gamer_profile_test");
-    await db.query(
-      "CREATE TABLE users_test.gamer_profile_test (LIKE users_test.gamer_profile INCLUDING ALL)",
-    );
+    await db.query("TRUNCATE TABLE test.gamer_profile CASCADE;");
   });
 
   // Clean up the database after each test
   afterEach(async () => {
-    await db.query("DROP TABLE IF EXISTS users_test.gamer_profile_test");
+    await db.query("TRUNCATE TABLE test.gamer_profile CASCADE;");
   });
 
   it("should add a gamer profile", (done) => {


### PR DESCRIPTION
Closes #32 

Now DB has `live` and `test` schemas so tests and real API calls don't affect each other. Previously, tests would call APIs and since the db path was hardcoded, it would update in the live db as well as the "test table" we make for each test. Now, when we run `npm test` it would include an environmental variable at the local level that tells the API whether to work with the live or test schema.

Related: #29 

ACTION ITEM:
@ubcesports/devteam-2024 please add the following to your local `.env` file:

`
LIVE_SCHEMA=live
TEST_SCHEMA=test
`