### PR TITLE
Added tooltips to buttons

### DIFF
--- a/client/src/app/check-in/add-user.tsx
+++ b/client/src/app/check-in/add-user.tsx
@@ -76,11 +76,16 @@ const AddUser = () => {
             { value: "2", label: "Tier 2" },
           ]}
         />
-        <Button
-          onClick={handleSubmit}
-          label="Add Gamer"
-          className="rounded bg-[#3A6AAC] px-4 py-2 text-[#DEE7EC] hover:bg-blue-500"
-        />
+        <div className="group relative">
+          <Button
+            onClick={handleSubmit}
+            label="Add Gamer"
+            className="rounded bg-[#3A6AAC] px-4 py-2 text-[#DEE7EC] hover:bg-blue-500"
+          />
+          <div className="absolute left-1/2 mt-2 hidden w-32 -translate-x-1/2 transform rounded bg-gray-100 p-2 text-center text-xs text-black group-hover:block">
+            This either creates a new profile or updates an existing one.
+          </div>
+        </div>
         <div className="col-span-5 col-start-1 row-span-1 row-start-2">
           <TextField
             label="Notes"

--- a/client/src/app/lounge/pc-info.tsx
+++ b/client/src/app/lounge/pc-info.tsx
@@ -38,12 +38,17 @@ const PCInfo: React.FC<PCInfoProps> = ({ pc, timeRemaining, isOccupied }) => {
           onChange={handleInputChange}
           className="rounded border border-[#62667B] bg-[#20222C] p-2 text-[#DEE7EC]"
         />
-        <button
-          className="h-full rounded border border-red-500 p-2 text-white hover:bg-red-500 hover:text-white"
-          onClick={handleClick}
-        >
-          Close
-        </button>
+        <div className="group relative">
+          <button
+            className="h-full rounded border border-red-500 p-2 text-white hover:bg-red-500 hover:text-white"
+            onClick={handleClick}
+          >
+            Close
+          </button>
+          <div className="absolute bottom-full left-1/2 mb-2 mt-2 hidden w-32 -translate-x-1/2 transform rounded bg-gray-100 p-2 text-center text-xs text-black group-hover:block">
+            This sign out will be associated with the provided exec name.
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Two buttons I found were good candidates to have tooltips for when you hover over them.

1. When adding a new user, our API's default behavior is to update a gamer profile if one already exists with the same student number, which is good as we don't necessarily have to create that functionality and execs can update profiles through add gamer. However, this means our "add gamer" button may not be clear in its function, so a tooltip here would be nice:

![image](https://github.com/user-attachments/assets/73c89a45-6a96-4153-977b-ca2464f5e8ea)

2. When we sign out a user, it would be good as a warning to let the exec know that the action following the click of the button will be associated with their name:

![image](https://github.com/user-attachments/assets/3c8b0baa-a330-42ff-8f9f-9d4e9dbcc155)

Open to better wording but I think this is a good QoL change :)

Note: decided not to use react-tooltip because I think it is an unnecessary dependency for such small changes, and I do think the result of doing it natively looks pretty good already. May go back on this if we decide to add more