### PR TITLE
Add Exec Name to Check Out

### DIFF
--- a/app/routes/gamer-activity.test.js
+++ b/app/routes/gamer-activity.test.js
@@ -46,6 +46,7 @@ describe("Activity API", () => {
         expect(res.body).to.have.property("student_number", "11223344");
         expect(res.body).to.have.property("pc_number", 1);
         expect(res.body).to.have.property("game", "Valorant");
+        expect(res.body).to.have.property("exec_name", null);
         done();
       });
   });
@@ -80,7 +81,7 @@ describe("Activity API", () => {
         expect(res.body).to.have.property("ended_at", null);
 
         request(app)
-          .patch("/api/activity/update/11223344")
+          .patch("/api/activity/update/11223344/John")
           .expect(201)
           .end((err, res) => {
             if (err) return done(err);
@@ -88,6 +89,7 @@ describe("Activity API", () => {
             expect(res.body).to.have.property("pc_number", 1);
             expect(res.body).to.have.property("game", "Valorant");
             expect(res.body).to.have.property("ended_at").and.not.equal(null);
+            expect(res.body).to.have.property("exec_name", "John");
             done();
           });
       });
@@ -95,7 +97,7 @@ describe("Activity API", () => {
 
   it("should return 404 if student does not have active activity", (done) => {
     request(app)
-      .patch("/api/activity/update/11223344")
+      .patch("/api/activity/update/11223344/John")
       .expect(404)
       .end((err, res) => {
         if (err) return done(err);

--- a/client/src/app/lounge/activity.tsx
+++ b/client/src/app/lounge/activity.tsx
@@ -24,7 +24,8 @@ export default function Activity() {
             Started ${startTimeFormatted} ・ 
             Ended ${endTimeFormatted || "N/A"} ・ 
             ${log.pcNumber} ・ 
-            ${log.game}`;
+            ${log.game} ・ 
+            Exec - ${log.execName}`;
   }
 
   if (logList.length === 0) {

--- a/client/src/app/lounge/pc-info.tsx
+++ b/client/src/app/lounge/pc-info.tsx
@@ -19,7 +19,8 @@ const PCInfo: React.FC<PCInfoProps> = ({ pc, isOccupied }) => {
   };
 
   const handleClick = async () => {
-    await checkOutGamer(pc.studentNumber, pc.pcNumber);
+    await checkOutGamer(pc.studentNumber, pc.pcNumber, execName);
+    window.location.reload();
   };
 
   const truncateName = (

--- a/client/src/interfaces/log.ts
+++ b/client/src/interfaces/log.ts
@@ -6,6 +6,7 @@ export interface Log {
   pcNumber: string;
   startedAt: Date;
   endedAt: Date;
+  execName: string;
 }
 
 export interface APILog {
@@ -16,4 +17,5 @@ export interface APILog {
   ended_at: string;
   first_name: string;
   last_name: string;
+  exec_name: string;
 }

--- a/client/src/services/activity.ts
+++ b/client/src/services/activity.ts
@@ -22,12 +22,17 @@ export const checkInGamer = async (activity: Activity) => {
 export const checkOutGamer = async (
   studentNumber: string,
   pcNumber: number,
+  execName: string,
 ) => {
   if (!studentNumber) {
     alert("This table is not occupied.");
     return;
   }
-  const url = `${API_URL}/activity/update/${studentNumber}`;
+  if (!execName) {
+    alert("Please enter your name.");
+    return;
+  }
+  const url = `${API_URL}/activity/update/${studentNumber}/${execName}`;
   const settings = {
     method: "PATCH",
     headers: {

--- a/client/src/store/log-store.ts
+++ b/client/src/store/log-store.ts
@@ -19,6 +19,7 @@ const updateLogList = (data: APILog[]) => {
       pcNumber: log.pc_number,
       startedAt: log.started_at,
       endedAt: log.ended_at,
+      execName: log.exec_name,
     };
   });
 


### PR DESCRIPTION
closes #49 

- Update live and test databases with new column exec_name
- Update PATCH endpoint to have new param name that associates executives with sign outs
- Update activity to reflect execs
- Add force refresh on check-out, so activity and pcinfo re-renders with newest info (+ it makes it look like it's doing something)

![Alt](https://media.giphy.com/media/LKG63uTYkk26Is57yY/giphy.gif?cid=790b7611785bwq8h041gc9nhbp61yguuah3ng5l4aryudr2g&ep=v1_gifs_search&rid=giphy.gif&ct=g)