### PR TITLE
added check for tier one gamers

### DIFF
--- a/app/routes/gamer-activity.js
+++ b/app/routes/gamer-activity.js
@@ -91,6 +91,8 @@ router.get("/activity/all/recent", async (req, res) => {
  * @apiSuccess {String} gamer_activity.started_at Datetime when the activity started.
  *
  * @apiError {String} 500 Server error.
+ * @apiError {String} 404 Foreign key not found.
+ * @apiError {String} 400 Tier 1 members can only book one PC per day.
  */
 router.post("/activity", async (req, res) => {
   const { student_number, pc_number, game } = req.body;
@@ -98,12 +100,29 @@ router.post("/activity", async (req, res) => {
     .tz("America/Los_Angeles")
     .format("YYYY-MM-DD HH:mm");
 
+  const tierOneCheckQuery = `
+    SELECT ga.*
+    FROM ${schema}.gamer_activity ga
+    JOIN ${schema}.gamer_profile gp ON ga.student_number = gp.student_number
+    WHERE ga.student_number = $1
+    AND gp.membership_tier = 1
+    AND DATE(ga.started_at::timestamp) = DATE($2::timestamp)
+  `;
   const query = `INSERT INTO ${schema}.gamer_activity 
         (student_number, pc_number, game, started_at) 
         VALUES ($1, $2, $3, $4) 
         RETURNING *`;
 
   try {
+    const tierOneCheckResult = await db.query(tierOneCheckQuery, [
+      student_number,
+      started_at,
+    ]);
+    if (tierOneCheckResult.rows.length > 0) {
+      return res
+        .status(400)
+        .send("Tier 1 members can only sign in once a day.");
+    }
     const result = await db.query(query, [
       student_number,
       pc_number,

--- a/client/src/app/check-in/check-in.tsx
+++ b/client/src/app/check-in/check-in.tsx
@@ -73,8 +73,8 @@ const CheckIn = () => {
     }
     try {
       await checkInGamer(checkInData);
-    } catch {
-      alert("Student not found.");
+    } catch (error) {
+      alert(error.message);
       return;
     }
     const addedProfile = await getGamerProfile(checkInData.studentNumber);

--- a/client/src/services/activity.ts
+++ b/client/src/services/activity.ts
@@ -15,6 +15,11 @@ export const checkInGamer = async (activity: Activity) => {
     body: JSON.stringify(activity),
   };
   const response = await fetch(url, settings);
+  if (response.status === 400) {
+    throw new Error("Tier 1 members can only check in once a day.");
+  } else if (response.status === 404) {
+    throw new Error("Student not found.");
+  }
   const data = await response.json();
   return data;
 };


### PR DESCRIPTION
closes #54 

- Adds query before we POST an activity to see if a tier 1 gamer has already checked in that day
- Updated documentation to reflect new 400 response status
- Added two tests