### PR TITLE
create action for deploying to ecr

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -2,6 +2,9 @@ name: Backend Unit Tests
 
 on:
   workflow_call:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -1,12 +1,7 @@
 name: Backend Unit Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,23 @@ jobs:
   backend-unit-tests:
     uses: ./.github/workflows/backend-unit-tests.yml
     secrets: inherit
-  
+
   frontend-unit-tests:
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets: inherit
 
-  deploy:
+  deploy-backend:
     needs: backend-unit-tests
     uses: ./.github/workflows/push-to-ecr.yml
     secrets: inherit
+    with:
+      image-tag: "backend-${{ github.sha }}"
+      layer: "app"
+  
+  deploy-frontend:
+    needs: frontend-unit-tests
+    uses: ./.github/workflows/push-to-ecr.yml
+    secrets: inherit
+    with:
+      image-tag: "frontend-${{ github.sha }}"
+      layer: "client"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,3 +36,15 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Check Directory
+        run: ls -la
+      
+      - name: Build, tag, and push image to Amazon ECR
+        env: 
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: "ubcea/lounge-hub"
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   backend-unit-tests:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,6 @@ jobs:
       
       - name: Build, tag, and push image to Amazon ECR - Backend
         run: |
-          docker build -t app .
+          docker build -t app -f app/Dockerfile .
           docker tag app:latest ${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
           docker push ${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       image-tag: "backend-${{ github.sha }}"
       layer: "app"
-  
+
   deploy-frontend:
     needs: frontend-unit-tests
     uses: ./.github/workflows/push-to-ecr.yml
@@ -32,3 +32,13 @@ jobs:
     with:
       image-tag: "frontend-${{ github.sha }}"
       layer: "client"
+    
+  deploy-nginx:
+    needs: 
+      - deploy-frontend
+      - deploy-backend
+    uses: ./.github/workflows/push-to-ecr.yml
+    secrets: inherit
+    with:
+      image-tag: "nginx-${{ github.sha }}"
+      layer: "nginx"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,17 @@ jobs:
         with:
           node-version: 20.4.0
 
-      - name: Install dependencies
+      - name: Install dependencies backend
         run: npm ci
         working-directory: ./app
 
-      - name: Build and push Docker images
-        run: |
-          echo ${{ secrets.AWS_ACCESS_KEY_ID }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-          docker build -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest .
-          docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest
-        working-directory: ./app
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,5 @@ jobs:
           ECR_REPOSITORY: "ubcea/lounge-hub"
           IMAGE_TAG: app-latest
         run: |
-          echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f app/Dockerfile .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,12 +32,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
       
-      - name: Build, tag, and push image to Amazon ECR - Backend
+      - name: Build, tag, and push docker image to Amazon ECR Public
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: d0w1o5s2
+          REPOSITORY: ubcea/lounge-hub
+          IMAGE_TAG: "backend-${{ github.sha }}"
         run: |
-          docker build -t app -f app/Dockerfile .
-          docker tag app:latest ${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
-          docker push ${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG -f app/Dockerfile .
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
     with:
       image-tag: "frontend-${{ github.sha }}"
       layer: "client"
-    
+
   push-nginx-image:
-    needs: 
+    needs:
       - push-backend-image
       - push-frontend-image
     uses: ./.github/workflows/push-to-ecr.yml
@@ -42,18 +42,18 @@ jobs:
     with:
       image-tag: "nginx-${{ github.sha }}"
       layer: "nginx"
-  
+
   deploy:
     runs-on: ubuntu-latest
     needs: push-nginx-image
     steps:
       - name: Execute commands via SSM
-        id : execute_command
+        id: execute_command
         run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ secrets.AWS_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=["echo "Commands to be executed" ",
+            --parameters 'commands=["echo \"Commands to be executed\"",
                                     "whoami"]' \
             --comment "Deploying comment" \
             --query "Command.CommandId" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets: inherit
 
-  deploy-backend:
+  push-backend-image:
     needs: backend-unit-tests
     uses: ./.github/workflows/push-to-ecr.yml
     secrets: inherit
@@ -25,7 +25,7 @@ jobs:
       image-tag: "backend-${{ github.sha }}"
       layer: "app"
 
-  deploy-frontend:
+  push-frontend-image:
     needs: frontend-unit-tests
     uses: ./.github/workflows/push-to-ecr.yml
     secrets: inherit
@@ -33,12 +33,31 @@ jobs:
       image-tag: "frontend-${{ github.sha }}"
       layer: "client"
     
-  deploy-nginx:
+  push-nginx-image:
     needs: 
-      - deploy-frontend
-      - deploy-backend
+      - push-backend-image
+      - push-frontend-image
     uses: ./.github/workflows/push-to-ecr.yml
     secrets: inherit
     with:
       image-tag: "nginx-${{ github.sha }}"
       layer: "nginx"
+  
+  deploy:
+    runs-on: ubuntu-latest
+    needs: push-nginx-image
+    steps:
+      - name: Execute commands via SSM
+        id : execute_command
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids ${{ secrets.AWS_INSTANCE_ID }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters 'commands=["echo "Commands to be executed" ",
+                                    "whoami"]' \
+            --comment "Deploying comment" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "Command ID: $COMMAND_ID"
+          echo "::set-output name=command_id::$COMMAND_ID"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to ECR
+name: Main Workflow
 
 on:
   push:
@@ -9,41 +9,15 @@ on:
       - main
 
 jobs:
-  build:
-    name: Build and Push Images
-    runs-on: ubuntu-latest
+  backend-unit-tests:
+    uses: ./.github/workflows/backend-unit-tests.yml
+    secrets: inherit
+  
+  frontend-unit-tests:
+    uses: ./.github/workflows/frontend-unit-tests.yml
+    secrets: inherit
 
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 20.4.0
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      
-      - name: Login to Amazon ECR Public
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
-      
-      - name: Build, tag, and push docker image to Amazon ECR Public
-        env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          REGISTRY_ALIAS: d0w1o5s2
-          REPOSITORY: ubcea/lounge-hub
-          IMAGE_TAG: "backend-${{ github.sha }}"
-        run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG -f app/Dockerfile .
-          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+  deploy:
+    needs: backend-unit-tests
+    uses: ./.github/workflows/push-to-ecr.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,15 +35,9 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Check Directory
-        run: ls -la
       
       - name: Build, tag, and push image to Amazon ECR - Backend
-        env: 
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: "ubcea/lounge-hub"
-          IMAGE_TAG: app-latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f app/Dockerfile .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t app .
+          docker tag app:latest ${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
+          docker push ${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to ECR
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20.4.0
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./app
+
+      - name: Build and push Docker images
+        run: |
+          echo ${{ secrets.AWS_ACCESS_KEY_ID }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+          docker build -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest .
+          docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest
+        working-directory: ./app

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,8 @@ jobs:
         with:
           node-version: 20.4.0
 
-      - name: Install dependencies backend
+      - name: Install dependencies
         run: npm ci
-        working-directory: ./app
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -40,11 +39,10 @@ jobs:
       - name: Check Directory
         run: ls -la
       
-      - name: Build, tag, and push image to Amazon ECR
+      - name: Build, tag, and push image to Amazon ECR - Backend
         env: 
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: "ubcea/lounge-hub"
-          IMAGE_TAG: latest
+          IMAGE_TAG: app-latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: push-nginx-image
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
       - name: Execute commands via SSM
         id: execute_command
         run: |

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -1,12 +1,7 @@
 name: Frontend Unit Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -2,6 +2,9 @@ name: Frontend Unit Tests
 
 on:
   workflow_call:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -48,5 +48,5 @@ jobs:
           REGISTRY_ALIAS: d0w1o5s2
           REPOSITORY: ubcea/lounge-hub
         run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }} ./${{ inputs.layer }}
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }} --target prod ./${{ inputs.layer }}
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }}

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -4,14 +4,13 @@ on:
   workflow_call:
     inputs:
       image-tag:
-        description: 'The tag of the image to deploy'
+        description: "The tag of the image to deploy"
         required: true
         type: string
       layer:
-        description: 'The layer of the application to deploy'
+        description: "The layer of the application to deploy"
         required: true
         type: string
-      
 
 jobs:
   build:
@@ -31,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -2,6 +2,16 @@ name: Deploy to ECR
 
 on:
   workflow_call:
+    inputs:
+      image-tag:
+        description: 'The tag of the image to deploy'
+        required: true
+        type: string
+      layer:
+        description: 'The layer of the application to deploy'
+        required: true
+        type: string
+      
 
 jobs:
   build:
@@ -26,19 +36,18 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      
+
       - name: Login to Amazon ECR Public
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
-      
+
       - name: Build, tag, and push docker image to Amazon ECR Public
         env:
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           REGISTRY_ALIAS: d0w1o5s2
           REPOSITORY: ubcea/lounge-hub
-          IMAGE_TAG: "backend-${{ github.sha }}"
         run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG -f app/Dockerfile .
-          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }} -f ${{ inputs.layer }}/Dockerfile .
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }}

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -1,0 +1,44 @@
+name: Deploy to ECR
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20.4.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+      
+      - name: Build, tag, and push docker image to Amazon ECR Public
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: d0w1o5s2
+          REPOSITORY: ubcea/lounge-hub
+          IMAGE_TAG: "backend-${{ github.sha }}"
+        run: |
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG -f app/Dockerfile .
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: us-east-1
 
       - name: Login to Amazon ECR Public
         id: login-ecr-public

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: us-west-2
 
       - name: Login to Amazon ECR Public
         id: login-ecr-public

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -48,5 +48,5 @@ jobs:
           REGISTRY_ALIAS: d0w1o5s2
           REPOSITORY: ubcea/lounge-hub
         run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }} -f ${{ inputs.layer }}/Dockerfile .
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }} ./${{ inputs.layer }}
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:${{ inputs.image-tag }}

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx
+FROM nginx AS base
 COPY default.conf /etc/nginx/conf.d/default.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx AS base
+FROM nginx AS prod
 COPY default.conf /etc/nginx/conf.d/default.conf

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typescript-eslint": "^8.13.0"
   },
   "scripts": {
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,yml}\"",
     "lint": "eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzg0bDd4Ym1ucHBoZ2xybGRpNGs5MHFjajF6Y2h0OXhmMGpoZ3BjaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/b8RQzkElbBsXqEPF2X/giphy.gif)

## Description
This PR is the start of the CI/CD pipeline for the repo. On commits pushed to main (NOT on PR), new images for the backend, frontend and nginx proxy will be pushed to our AWS ECR repository. 

There were also a few refactors done to our Github Action pipelines:
- Unit tests are now called on workflow trigger, meaning they are ran again before we deploy. 
- Pushing to ECR is now a _reusable workflow_ so its generalized to push whatever image from whatever folder as long as its given the right parameters. This way we don't have repeat code for pushing the 3 images mentioned above. 
- The main `deploy.yml` file calls the separate workflows as per the image below
<img width="1020" alt="Screenshot 2024-12-11 at 8 59 23 PM" src="https://github.com/user-attachments/assets/f8b4b57e-a782-4d4a-abb7-9a43c3bd44af" />
- Right now, it follows:
  - Unit tests
  - Push images
  - Deploy

## Next Steps
Since I mentioned this was the first step, the next step will be to automatically start the docker containers in the EC2 instance to reflect the latest pushed images. You can see a preview of this in the `deploy` step in `deploy.yml` where I am using AWS SSM to make some `echo` calls. 

## Notes
- There are 3 new environment secrets needed (this is only for Github Actions and don't need these in your local environment)
  - AWS_INSTANCE_ID
  - AWS_ACCESS_KEY_ID
  - AWS_SECRET_ACCESS_KEY
- Here is the [Successul run](https://github.com/ubcesports/lounge-hub/actions/runs/12290018127) before I removed deploying on PR commits. 