### PR TITLE
fix nextjs npm run build for prod

### DIFF
--- a/client/src/app/contexts/AuthContext.tsx
+++ b/client/src/app/contexts/AuthContext.tsx
@@ -13,6 +13,10 @@ interface AuthContextProps {
 
 // AuthContext to wrap the application around
 const AuthContext: React.FC<AuthContextProps> = ({ children }) => {
+  if (typeof window === "undefined") {
+    return null; // Return null on the server side
+  }
+
   return (
     <Auth0Provider
       domain={process.env.NEXT_PUBLIC_DOMAIN || ""}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,8 @@ services:
       target: prod
     environment:
       - TZ=America/Los_Angeles
+    env_file:
+      - .env
     platform: linux/amd64
 
   nginx:


### PR DESCRIPTION
## Bug
- After #73 was merged, there was a bug in prod where the production version of our app wasn't building due to `window` being undefined in the NextJs server context. 

## Fix
- Checking if the window is defined before doing anything fixed it (hopefully). Also adding the new environment variables to the prod docker compose. 

To prevent more bugs in prod from happening, we should probably build an sudo image of prod before we merge, or make staging envionment haha