### PR TITLE
downgrade tier1 check to warning

### DIFF
--- a/app/routes/gamer-activity.js
+++ b/app/routes/gamer-activity.js
@@ -120,17 +120,17 @@ router.post("/activity", async (req, res) => {
       student_number,
       started_at,
     ]);
-    if (tierOneCheckResult.rows.length > 0) {
-      return res
-        .status(400)
-        .send("Tier 1 members can only sign in once a day.");
-    }
     const result = await db.query(query, [
       student_number,
       pc_number,
       game,
       started_at,
     ]);
+    if (tierOneCheckResult.rows.length > 0) {
+      return res
+        .status(400)
+        .send(result.rows[0]);
+    }
     res.status(201).send(result.rows[0]);
   } catch (err) {
     if (err.code === FK_VIOLATION) {


### PR DESCRIPTION
We downgrade the tier 1 gamer check to a warning instead - this is because often times we _do_ allow the user to sign in twice a day or we have to change their pcs. Not the best solution but the fastest one as we are launching tomorrow. Up next we should change this to do: check if tier 1 has signed in once, if so -> warn and ask if we wish to proceed -> then sign in