### PR TITLE
Fixed fetchActivites bug

### DIFF
--- a/client/src/app/lounge/pc-info.tsx
+++ b/client/src/app/lounge/pc-info.tsx
@@ -21,7 +21,7 @@ const PCInfo: React.FC<PCInfoProps> = ({ pcNumber }) => {
 
   const handleSignOutClick = async () => {
     await checkOutGamer(pc.studentNumber, pc.pcNumber, execName);
-    fetchActivities(0, "");
+    fetchActivities(1, "");
   };
   const handleExecClick = () => {
     const store = useBoundStore.getState();


### PR DESCRIPTION
Addresses the bug created in #107 where a value of 0 was fed into fetchActvities instead of a 1

Picture of the bug which appears after someone gets signed out  the activity log does not get updated
![image](https://github.com/user-attachments/assets/809ba3e8-2a67-4993-aa2c-5500c04dc5c9)

