### PR TITLE
added overtime info

### DIFF
--- a/client/src/app/lounge/pc-info.tsx
+++ b/client/src/app/lounge/pc-info.tsx
@@ -76,13 +76,13 @@ const PCInfo: React.FC<PCInfoProps> = ({ pcNumber }) => {
     const hours = Math.floor(timeDiff / (1000 * 60 * 60));
     const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
 
-    const formattedHours = hours.toString();
-    const formattedMinutes = minutes.toString().padStart(2, "0");
+    const formattedHours = Math.abs(hours).toString();
+    const formattedMinutes = Math.abs(minutes).toString().padStart(2, "0");
 
     const timeLeft =
       timeDiff >= 0
         ? `${formattedHours}h ${formattedMinutes}m left`
-        : "Time up";
+        : `Time exceeded ${formattedHours}h ${formattedMinutes}m`;
 
     return `Started ${date.getHours()}:${date.getMinutes().toString().padStart(2, "0")} \u00B7 ${game} \u00B7 ${timeLeft}`;
   };
@@ -107,7 +107,7 @@ const PCInfo: React.FC<PCInfoProps> = ({ pcNumber }) => {
           </p>
           <p className="text-1xl mb-1 ml-2 max-w-xs truncate text-[#62667B]">
             {pcStatus === PCStatus.Busy
-              ? `- ${truncateName(pc.firstName, pc.lastName, pc.studentNumber, maxLength)}`
+              ? `- ${truncateName(pc.firstName, pc.lastName, pc.studentNumber, maxLength)} - Tier ${pc.membershipTier}`
               : ""}
           </p>
         </div>

--- a/client/src/app/lounge/pc-station.tsx
+++ b/client/src/app/lounge/pc-station.tsx
@@ -7,7 +7,11 @@ interface PCStationProps {
   onClick: (pc: PC, timeRemaining: string, pcStatus: PCStatus) => void;
 }
 
-const PCStation: React.FC<PCStationProps> = ({ pc, pcStatus, onClick }) => {
+const PCStation: React.FC<PCStationProps> = ({
+  pc,
+  pcStatus,
+  onClick,
+}) => {
   const [timeRemaining, setTimeRemaining] = useState<string>("");
 
   const calculateTimeRemaining = (

--- a/client/src/app/lounge/pc-station.tsx
+++ b/client/src/app/lounge/pc-station.tsx
@@ -7,11 +7,7 @@ interface PCStationProps {
   onClick: (pc: PC, timeRemaining: string, pcStatus: PCStatus) => void;
 }
 
-const PCStation: React.FC<PCStationProps> = ({
-  pc,
-  pcStatus,
-  onClick,
-}) => {
+const PCStation: React.FC<PCStationProps> = ({ pc, pcStatus, onClick }) => {
   const [timeRemaining, setTimeRemaining] = useState<string>("");
 
   const calculateTimeRemaining = (


### PR DESCRIPTION
closes #103 
- added time exceeded and membership tier to the pc info component

![image](https://github.com/user-attachments/assets/04fffee3-4fac-4a99-9c9f-140d6dcc647f)
