### PR TITLE
fix time exceeded bug

### DIFF
--- a/client/src/app/lounge/pc-info.tsx
+++ b/client/src/app/lounge/pc-info.tsx
@@ -73,7 +73,7 @@ const PCInfo: React.FC<PCInfoProps> = ({ pcNumber }) => {
     }
 
     const timeDiff = endTime.getTime() - currentTime.getTime();
-    
+
     if (timeDiff >= 0) {
       const hours = Math.floor(timeDiff / (1000 * 60 * 60));
       const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
@@ -83,11 +83,12 @@ const PCInfo: React.FC<PCInfoProps> = ({ pcNumber }) => {
 
       const timeLeft = `${formattedHours}h ${formattedMinutes}m left`;
       return `Started ${date.getHours()}:${date.getMinutes().toString().padStart(2, "0")} \u00B7 ${game} \u00B7 ${timeLeft}`;
-
     } else {
       const exceededTime = currentTime.getTime() - endTime.getTime();
       const hours = Math.floor(exceededTime / (1000 * 60 * 60));
-      const minutes = Math.floor((exceededTime % (1000 * 60 * 60)) / (1000 * 60));
+      const minutes = Math.floor(
+        (exceededTime % (1000 * 60 * 60)) / (1000 * 60),
+      );
 
       const formattedHours = hours.toString();
       const formattedMinutes = minutes.toString().padStart(2, "0");

--- a/client/src/app/lounge/pc-info.tsx
+++ b/client/src/app/lounge/pc-info.tsx
@@ -73,18 +73,28 @@ const PCInfo: React.FC<PCInfoProps> = ({ pcNumber }) => {
     }
 
     const timeDiff = endTime.getTime() - currentTime.getTime();
-    const hours = Math.floor(timeDiff / (1000 * 60 * 60));
-    const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
+    
+    if (timeDiff >= 0) {
+      const hours = Math.floor(timeDiff / (1000 * 60 * 60));
+      const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
 
-    const formattedHours = Math.abs(hours).toString();
-    const formattedMinutes = Math.abs(minutes).toString().padStart(2, "0");
+      const formattedHours = hours.toString();
+      const formattedMinutes = minutes.toString().padStart(2, "0");
 
-    const timeLeft =
-      timeDiff >= 0
-        ? `${formattedHours}h ${formattedMinutes}m left`
-        : `Time exceeded ${formattedHours}h ${formattedMinutes}m`;
+      const timeLeft = `${formattedHours}h ${formattedMinutes}m left`;
+      return `Started ${date.getHours()}:${date.getMinutes().toString().padStart(2, "0")} \u00B7 ${game} \u00B7 ${timeLeft}`;
 
-    return `Started ${date.getHours()}:${date.getMinutes().toString().padStart(2, "0")} \u00B7 ${game} \u00B7 ${timeLeft}`;
+    } else {
+      const exceededTime = currentTime.getTime() - endTime.getTime();
+      const hours = Math.floor(exceededTime / (1000 * 60 * 60));
+      const minutes = Math.floor((exceededTime % (1000 * 60 * 60)) / (1000 * 60));
+
+      const formattedHours = hours.toString();
+      const formattedMinutes = minutes.toString().padStart(2, "0");
+
+      const timeLeft = `Time exceeded ${formattedHours}h ${formattedMinutes}m`;
+      return `Started ${date.getHours()}:${date.getMinutes().toString().padStart(2, "0")} \u00B7 ${game} \u00B7 ${timeLeft}`;
+    }
   };
 
   return (


### PR DESCRIPTION
closes #124 

fixed the timeDiff constant calculations -- was calculating the timeDiff as endtime - current but should be other way around when exceeded

i just wanted a picture to demo but this makes sense I think.

<img width="521" height="130" alt="Screenshot 2025-07-29 at 2 39 22 PM" src="https://github.com/user-attachments/assets/515efad9-cdef-47c8-b0e6-fa21e706858c" />
